### PR TITLE
update to lodash, remove underscore mixin

### DIFF
--- a/.validate.json
+++ b/.validate.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "lint": "jshint ."
+  },
+  "pre-commit": ["lint", "validate", "test"]
+}

--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ The array of filtered models with `offset` and/or `limit` applied (if set).
 
 This property is present and set to `true`. see [ampersand-collection](https://github.com/AmpersandJS/ampersand-collection#a-quick-note-about-instanceof-checks) for more info
 
-### all the underscore methods
-
-Since we're already depending on underscore for much of the functionality in this module, we also mixin underscore methods into the paginated collection in the same way that Backbone does for collections.
-
-This means you can just call `collection.each()` or `collection.find()` to find/filter/iterate the models in the paginated collection. You can see which underscore methods are included by referencing [ampersand-collection-underscore-mixin](https://github.com/AmpersandJS/ampersand-collection-underscore-mixin).
-
 ### PaginatedSubcollection.extend(mixins...)
 
 PaginatedSubcollection attaches `extend` to the constructor so if you want to add custom methods to your PaginatedSubcollection constructor, it's easy:

--- a/ampersand-paginated-subcollection.js
+++ b/ampersand-paginated-subcollection.js
@@ -1,9 +1,8 @@
 /*AMPERSAND_VERSION*/
 /*jshint eqnull: true*/
 var Events = require('ampersand-events');
-var underscoreMixins = require('ampersand-collection-underscore-mixin');
 var classExtend = require('ampersand-class-extend');
-var extend = require('amp-extend');
+var assign = require('lodash.assign');
 var slice = Array.prototype.slice;
 
 
@@ -14,7 +13,7 @@ function PagedCollection(collection, spec) {
     this.listenTo(this.collection, 'all', this._onCollectionEvent);
 }
 
-extend(PagedCollection.prototype, Events, underscoreMixins, {
+assign(PagedCollection.prototype, Events, {
     // Public API
 
     // Update config with potentially new limit/offset

--- a/package.json
+++ b/package.json
@@ -24,18 +24,20 @@
   },
   "homepage": "https://github.com/AmpersandJS/ampersand-paginated-subcollection",
   "devDependencies": {
-    "ampersand-collection": "^1.4.0",
+    "ampersand-collection": "^1.4.5",
     "jshint": "^2.6.0",
-    "precommit-hook": "^1.0.7",
+    "precommit-hook": "^2.0.1",
     "run-browser": "^2.0.1",
-    "tap-spec": "^2.2.0",
+    "tap-spec": "^3.0.0",
     "tape": "^3.4.0"
   },
+  "files": [
+    "ampersand-paginated-subcollection.js"
+  ],
   "dependencies": {
-    "amp-extend": "^1.0.1",
-    "ampersand-class-extend": "^1.0.1",
-    "ampersand-collection-underscore-mixin": "^1.0.3",
-    "ampersand-events": "^1.0.1",
-    "ampersand-state": "^4.4.4"
+    "ampersand-class-extend": "^1.0.2",
+    "ampersand-events": "^1.1.1",
+    "ampersand-state": "^4.5.2",
+    "lodash.assign": "^3.0.0"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,5 @@
 var test = require('tape');
-var mixins = require('ampersand-collection-underscore-mixin');
-var Collection = require('ampersand-collection').extend(mixins);
+var Collection = require('ampersand-collection');
 var SubCollection = require('../ampersand-paginated-subcollection');
 var Model = require('ampersand-state');
 
@@ -15,7 +14,7 @@ var Widget = Model.extend({
 });
 
 // our base collection
-var Widgets = Collection.extend(mixins, {
+var Widgets = Collection.extend({
     model: Widget,
     comparator: 'awesomeness'
 });


### PR DESCRIPTION
In this branch the only underscore version after an npm i is in jshint.
