### PR TITLE
Should run collection methods on collection

### DIFF
--- a/ampersand-paginated-subcollection.js
+++ b/ampersand-paginated-subcollection.js
@@ -118,7 +118,7 @@ var collectionMethods = [
 
 collectionMethods.forEach(function (method) {
     PaginatedCollection.prototype[method] = function () {
-        return this.collection[method].apply(this, arguments);
+        return this.collection[method].apply(this.collection, arguments);
     };
 });
 


### PR DESCRIPTION
If not, and you have a subcollection as the collection, then you get infinite recursion and a bad time.

This fixes a serious issue that appears when you filter a paginated subcollection or vise-versa.